### PR TITLE
Add Tag to exclude buildings from being colored

### DIFF
--- a/src/MaterialColor/Painter.cs
+++ b/src/MaterialColor/Painter.cs
@@ -25,6 +25,7 @@ namespace MaterialColor
         };
 
         private static readonly string ExcludeKeyword = "NoPaint";
+        private static readonly Tag ExcludedTag = new Tag("NoPaint");
 
         public static void Refresh()
         {
@@ -48,7 +49,7 @@ namespace MaterialColor
 
         public static void UpdateBuildingColor(BuildingComplete building)
         {
-            if (building.name == "PixelPackComplete" || building.name == "WallpaperComplete" || building.name.Contains(ExcludeKeyword))
+            if (building.name == "PixelPackComplete" || building.name == "WallpaperComplete" || building.name.Contains(ExcludeKeyword) || building.HasTag(ExcludedTag))
             {
                 return;
             }


### PR DESCRIPTION
Requiring the ID of a building to have `NoPaint` in it creates long, ugly, and unwieldy names.  By also checking for a tag, mod authors can easily exclude their building from being painted by calling `go.AddTag(new Tag("NoPaint"));` in their building's `DoPostConfigureComplete` (or otherwise adding that tag to their building)