### PR TITLE
Fix Material color to check for tiles dynamically instead of using a …

### DIFF
--- a/src/MaterialColor/Helpers/MaterialHelper.cs
+++ b/src/MaterialColor/Helpers/MaterialHelper.cs
@@ -8,7 +8,7 @@
     {
         public static bool CellIndexToElement(int cellIndex, out Element element)
         {
-            byte cellElementIndex = Grid.ElementIdx[cellIndex];
+            ushort cellElementIndex = Grid.ElementIdx[cellIndex];
 
             element = ElementLoader.elements?[cellElementIndex];
 

--- a/src/MaterialColor/Painter.cs
+++ b/src/MaterialColor/Painter.cs
@@ -51,7 +51,7 @@ namespace MaterialColor
 
                 Filter(building.name, ref color);
 
-                if (State.TileNames.Contains(building.name))
+                if (building.gameObject.TryGetComponent<KAnimGridTileVisualizer>(out _))
                 {
                     ApplyColorToTile(building, color);
                 }
@@ -117,7 +117,7 @@ namespace MaterialColor
 
                 var tags = traversedTreeFilterable.Field<List<Tag>>("acceptedTags").Value.ToArray();
 
-                treeFilterable.OnFilterChanged(tags);
+                treeFilterable.OnFilterChanged(new HashSet<Tag>(tags));
 
                 return true;
             }

--- a/src/MaterialColor/Patches/ApplyColors.cs
+++ b/src/MaterialColor/Patches/ApplyColors.cs
@@ -107,11 +107,11 @@ namespace MaterialColor.Patches
         [HarmonyPatch(typeof(Deconstructable), "OnCompleteWork")]
         public static class Deconstructable_OnCompleteWork_MatCol
         {
-            public static void Postfix(Deconstructable __instance)
+            public static void Prefix(Deconstructable __instance)
             {
                 try
                 {
-                    if (State.TileNames.Contains(__instance.name))
+                    if (__instance.gameObject.TryGetComponent<KAnimGridTileVisualizer>(out _))
                     {
                         State.TileColors[__instance.GetCell()] = null;
                     }

--- a/src/MaterialColor/State.cs
+++ b/src/MaterialColor/State.cs
@@ -17,22 +17,6 @@
 
         public static bool ConfigChanged;
 
-        // TODO: load from file instead
-        [NotNull]
-        public static readonly List<string> TileNames = new List<string>
-        {
-            "Tile",
-            "MeshTile",
-            "GlassTile",
-            "BunkerTile",
-            "InsulationTile",
-            "GasPermeableMembrane",
-            "TilePOI",
-            "PlasticTile",
-            "MetalTile",
-            "CarpetTile",
-        }.Select(name => name + "Complete").ToList();
-
         public static Core Common = new Core("MaterialColor", "1739635014", "Config", false);
 
         private static Config _config = new Config();


### PR DESCRIPTION
The current live version of the mod uses a static list of building IDs for applying the tile-tint. this doesnt work for any tiles added by other mods and base tiles that arent added to the list like the storage tile.

the change made in this request adjusts this behavior to instead check for a KAnimGridTileVisualizer component, something present on all these tiles to work with all tiles klei or other mods add.

The ElementIdx also changed recently from byte to ushort, allowing mods and klei to add more than 256 elements in total, so I adjusted that aswell