### PR TITLE
Updates Worker reference to StandardWorker

### DIFF
--- a/src/ChainedDeconstruction/Patches/ChainedDeconstruction.cs
+++ b/src/ChainedDeconstruction/Patches/ChainedDeconstruction.cs
@@ -16,13 +16,13 @@ namespace ChainedDeconstruction
             typeof(float),
             typeof(byte),
             typeof(int),
-            typeof(Worker),
+            typeof(StandardWorker),
         }
     )]
     public class ChainedDeconstruction : KMod.UserMod2
     {
         private static readonly MethodInfo ForceDeconstruct = AccessTools.Method(typeof(Deconstructable), "OnCompleteWork");
-        private static readonly object[] NullWorkerParameter = new[] { (Worker)null };
+        private static readonly object[] NullWorkerParameter = new[] { (StandardWorker)null };
         private static readonly AccessTools.FieldRef<Deconstructable, bool> DestroyedGetter = AccessTools.FieldRefAccess<Deconstructable, bool>("destroyed");
 
         private static readonly string ConfigFileName = "Chainables.json";


### PR DESCRIPTION
With yesterdays update U53 the class Worker was renamed as StandardWorker. This pull request just applies this here. From limited local testing it's a sufficient fix.